### PR TITLE
Fix glitches when blitting to/from default framebuffer after resize

### DIFF
--- a/src/libANGLE/renderer/metal/FrameBufferMtl.mm
+++ b/src/libANGLE/renderer/metal/FrameBufferMtl.mm
@@ -319,6 +319,15 @@ angle::Result FramebufferMtl::blit(const gl::Context *context,
     gl::Rectangle sourceArea = sourceAreaIn;
     gl::Rectangle destArea   = destAreaIn;
 
+    // Update backbuffer dimensions
+    SurfaceMtl *backbuffer = mBackbuffer ? mBackbuffer : srcFrameBuffer->mBackbuffer;
+    if (backbuffer)
+    {
+        // Backbuffer might obtain new drawable, which means
+        // it might change the native texture dimensions.
+        ANGLE_TRY(backbuffer->ensureCurrentDrawableObtained(context));
+    }
+
     const gl::Rectangle srcFramebufferDimensions = srcFrameBuffer->getCompleteRenderArea();
 
     // If the destination is flipped in either direction, we will flip the source instead so that


### PR DESCRIPTION
Fixes a bug in Metal implementation of `glBlitFramebuffer()`, occurring when the read or write framebuffer bound was the default framebuffer. The first frame following a window resize would have incorrect viewport and scissor rectangles, essentially leading to single-frame transient flashing.

`FramebufferMtl::blit()` is updated to obtain an up-to-date drawable belonging to the default framebuffer, so that `FrameBufferState::getExtents()` can return valid texture dimensions.