### PR TITLE
Ease FramebufferTexture2DMultisampleEXT requirements on Metal

### DIFF
--- a/src/libANGLE/validationES2.cpp
+++ b/src/libANGLE/validationES2.cpp
@@ -7383,11 +7383,13 @@ bool ValidateFramebufferTexture2DMultisampleEXT(Context *context,
         return false;
     }
 
+#if !defined(ANGLE_ENABLE_METAL)
     if (attachment != GL_COLOR_ATTACHMENT0)
     {
         context->validationError(GL_INVALID_ENUM, kInvalidAttachment);
         return false;
     }
+#endif
 
     TextureTarget textargetPacked = FromGLenum<TextureTarget>(textarget);
     if (!ValidTexture2DDestinationTarget(context, textargetPacked))


### PR DESCRIPTION
The [`EXT_multisampled_render_to_texture`](https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_multisampled_render_to_texture.txt) defines that for `FramebufferTexture2DMultisampleEXT` the _attachment must be COLOR_ATTACHMENT0_ althtough there is no such limitation in the Metal renderer of ANGLE.

To enable resolving multisampled textures directly with `MTLStoreActionMultisampleResolve` used by the implementation of this extension, instead of a having to do a manual `glBlitFramebuffer` which is implemented with a custom blitting shader, the `COLOR_ATTACHMENT0` attachment requirement is lifted so that `FramebufferTexture2DMultisampleEXT` can be used for any color attachment.