### PR TITLE
Improve render pass load and store actions

### DIFF
--- a/src/libANGLE/renderer/metal/FrameBufferMtl.mm
+++ b/src/libANGLE/renderer/metal/FrameBufferMtl.mm
@@ -739,7 +739,8 @@ void FramebufferMtl::initLoadStoreActionOnRenderPassFirstStart(
     mtl::RenderPassAttachmentDesc &attachment = *attachmentOut;
 
     if (attachment.storeAction == MTLStoreActionDontCare ||
-        attachment.storeAction == MTLStoreActionMultisampleResolve)
+        attachment.storeAction == MTLStoreActionMultisampleResolve ||
+        (mBackbuffer && !mBackbuffer->preserveBuffer()))
     {
         // If we previously discarded attachment's content, then don't need to load it.
         attachment.loadAction = MTLLoadActionDontCare;

--- a/src/libANGLE/renderer/metal/RenderBufferMtl.mm
+++ b/src/libANGLE/renderer/metal/RenderBufferMtl.mm
@@ -75,27 +75,12 @@ angle::Result RenderbufferMtl::setStorageImpl(const gl::Context *context,
 
     if ((mTexture == nullptr || !mTexture->valid()) && (width != 0 && height != 0))
     {
-        if (actualSamples == 1 || (mFormat.hasDepthAndStencilBits() && mFormat.getCaps().resolve))
+        if (actualSamples == 1)
         {
             ANGLE_TRY(mtl::Texture::Make2DTexture(contextMtl, mFormat, static_cast<uint32_t>(width),
                                                   static_cast<uint32_t>(height), 1,
                                                   /* renderTargetOnly */ false,
                                                   /* allowFormatView */ false, &mTexture));
-
-            // Use implicit resolve for depth stencil texture whenever possible. This is because
-            // for depth stencil texture, if stencil needs to be blitted, a formatted clone has
-            // to be created. And it is expensive to clone a multisample texture.
-            if (actualSamples > 1)
-            {
-                // This format must supports implicit resolve
-                ASSERT(mFormat.getCaps().resolve);
-
-                ANGLE_TRY(mtl::Texture::Make2DMSTexture(
-                    contextMtl, mFormat, static_cast<uint32_t>(width),
-                    static_cast<uint32_t>(height), actualSamples,
-                    /* renderTargetOnly */ true,
-                    /* allowFormatView */ false, &mImplicitMSTexture));
-            }
         }
         else
         {


### PR DESCRIPTION
* Multisampled depth-stencil renderbuffers were repeatedly resolved in each pass, even if there weren't any blit operations to necessitate it. These incurred a heavy performance penalty in our app, and are therefore removed. See also: https://github.com/kakashidinho/metalangle/commit/38c3db8e674bd695707fc9eaee2e25ea6dbf54c6.
* In final pass of a frame, when drawing to a `CAMetalDrawable`, the existing contents of the drawable should not be loaded. We can use `MTLLoadActionDontCare` in such cases.